### PR TITLE
Ignore case on labels by map to lower case and capitalize first letter

### DIFF
--- a/src/main/java/org/neo4j/changelog/github/PRIssue.java
+++ b/src/main/java/org/neo4j/changelog/github/PRIssue.java
@@ -1,13 +1,12 @@
 package org.neo4j.changelog.github;
 
 
-import javax.annotation.Nonnull;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 
 public class PRIssue implements PullRequest {
 
@@ -107,7 +106,9 @@ public class PRIssue implements PullRequest {
                     if (isVersion(metaPart)) {
                         versionFilter.add(metaPart.trim());
                     } else if (!metaPart.trim().isEmpty()) {
-                        labelFilter.add(metaPart.trim());
+                        String label = metaPart.trim().toLowerCase();
+                        label = label.substring(0, 1).toUpperCase() + label.substring(1);
+                        labelFilter.add( label );
                     }
                 }
             }

--- a/src/test/java/org/neo4j/changelog/github/PRIssueTest.java
+++ b/src/test/java/org/neo4j/changelog/github/PRIssueTest.java
@@ -314,6 +314,18 @@ public class PRIssueTest {
         assertEquals("pr title [#1](http://test.com/link)", pr.getChangeText());
     }
 
+    @Test
+    public void prettyLabels() throws Exception
+    {
+        PRIssue pr = getPrIssue(1, "", "Bla bla bla\n" +
+                               "blala bla\n" +
+                               "bal\n" +
+                               "changelog: [Kernel, cypheR, imporT Tool]\n");
+
+        assertArrayEquals("Unexpected label array", new String[]{"Kernel", "Cypher", "Import tool"},
+                pr.getLabelFilter().toArray());
+    }
+
     private PRIssue getPrIssue(int number, String title, String body) {
         return getPrIssue(number, title, body, "http://test.com/link");
     }


### PR DESCRIPTION
This makes it easier to use tool and we can avoid changing the labels manually to make them suitable for headings in changelog.
